### PR TITLE
fix(aapt): Aapt broken and cannot recognize Android 5.0+ attributes

### DIFF
--- a/aapt/build.gradle
+++ b/aapt/build.gradle
@@ -28,5 +28,7 @@ android {
 }
 
 dependencies {
-
+    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.android.support:support-annotations:21.0.3'
+    compile 'com.android.support:recyclerview-v7:21.0.3'
 }


### PR DESCRIPTION
This should hopefully fix #36. By the way, where is `rootProject.ext.compileSdkVersion` defined? @tranleduy2000 See https://github.com/afollestad/material-dialogs/issues/310#issuecomment-78013131 for reference.