### PR TITLE
Update AndroidArtifactOutput.java, not exist (com.android.build.VariantOutput)

### DIFF
--- a/aosp/builder-model/src/main/java/com/android/builder/model/AndroidArtifactOutput.java
+++ b/aosp/builder-model/src/main/java/com/android/builder/model/AndroidArtifactOutput.java
@@ -17,7 +17,7 @@
 package com.android.builder.model;
 
 import com.android.annotations.NonNull;
-import com.android.build.VariantOutput;
+//import com.android.build.VariantOutput; this file is not exist
 
 import java.io.File;
 
@@ -25,7 +25,7 @@ import java.io.File;
  * The Actual output for a {@link AndroidArtifact}, which can be one file at the minimum or
  * several APKs in case of pure splits configuration.
  */
-public interface AndroidArtifactOutput extends VariantOutput {
+public interface AndroidArtifactOutput /*extends VariantOutput*/ {
 
     /**
      * Returns the name of the task used to generate this artifact output.


### PR DESCRIPTION
I just commented because some files are missing, I tried to replace them with some file which I found from :=[com.android.build](https://android.googlesource.com/platform/tools/base/+/d8ce584635897fc12f0a43618cbd69ce48f889e8/common/src/main/java/com/android/build), but it is not gonna work when you want to create an android apk